### PR TITLE
Remove #[used] from log.rs

### DIFF
--- a/fluidlite/src/log.rs
+++ b/fluidlite/src/log.rs
@@ -160,7 +160,6 @@ impl<F: FnMut(LogLevel, &str)> Logger for FnLogger<F> {
  */
 pub struct Log {
     levels: Vec<LogLevel>,
-    #[used]
     logger: Box<dyn Logger>,
 }
 


### PR DESCRIPTION
error: attribute must be applied to a `static` variable